### PR TITLE
Add company name to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+ERA MEDYA REKLAM SANAT MEDYA TASARIM  ltd. şti.
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary by Sourcery

Introduce initial Dependabot configuration with company header and weekly update schedule.

New Features:
- Add .github/dependabot.yml to schedule weekly dependency updates

Enhancements:
- Include company name in the Dependabot configuration header